### PR TITLE
Updated url for "start_url" in site.webmanifest

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -4,5 +4,5 @@
         "sizes": "192x192",
         "type": "image/png"
     }],
-    "start_url": "/"
+    "start_url": "http://geonb.snb.ca/rwm"
 }


### PR DESCRIPTION
"start_url" was set to "/".  If mobile users used the "Add to home screen" function in their mobile browser the wrong URL was assigned to the River Watch Mobile icon on the user's home screen.  The icon was assigned to "http://geonb.snb.ca/geonb".  Updating the "start_url" to "http://geonb.snb.ca/rwm" appears to fix this problem.